### PR TITLE
[WIP] Update docs to recommend Dawn Wallet

### DIFF
--- a/docs/Level-1/3-how-to-create-wallet.md
+++ b/docs/Level-1/3-how-to-create-wallet.md
@@ -18,13 +18,25 @@ Your wallet is only a tool for managing your Ethereum account. That means you ca
 That's because wallets don't have custody of your funds, you do. They're just a tool for managing what's really yours.
 
 
-## Easiest Way - Metamask 
+## Easiest Way - Dawn
+Dawn is an iPhone based Ethereum mobile wallet. 
+
+You download the app onto your iPhone and run through the onboarding to get it setup. It has a native Safari extension, which makes it very easy to use Gnars from your iPhones Safari web browser. 
+
+Download here: https://apps.apple.com/us/app/dawn-ethereum-wallet/id1673143782
+
+To use, you would go to the Gnars dapp (`gnars.wtf`) on Safari, and then when you click "Connect", "Settle Transaction" etc. a popup will appear which allows you to connect your wallet and interact with Gnars.
+
+A demo of how to use Dawn is here: ![Gnars Demo](https://youtube.com/shorts/GFpCSmBmxx0)
+
+
+## Backup
+If Dawn isn't supported on your platform (you're not using an iPhone), then MetaMask is the way to go:
 
 ![ezgif com-gif-maker](https://user-images.githubusercontent.com/85296013/213961063-c01ddd2a-523f-47bc-83a5-148a75b59c2b.gif)
 
 
 ![ezgif com-gif-maker_1](https://user-images.githubusercontent.com/85296013/213961142-b3a77e13-ff19-4777-8b62-c467e3f71c19.gif)
-
 
 
    


### PR DESCRIPTION
# Summary
Dawn Wallet (https://twitter.com/dawn_wallet) is an iOS based mobile Ethereum wallet. It makes interacting with Dapps seamless through its native Safari extension - meaning a user never has to leave their browser to use the dapp.

This PR updates the Gnars docs to highlight Dawn to users and recommends MetaMask if Dawn is not available on the users platform. 

Note: Merging this PR and updating the docs should wait until Dawn is available on the app store